### PR TITLE
Fix classification for Metaflow

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -129,6 +129,13 @@ landscape:
             twitter: 'https://twitter.com/MLflow'
             crunchbase: 'https://www.crunchbase.com/organization/databricks'
           - item:
+            name: Metaflow
+            homepage_url: 'https://metaflow.org/'
+            repo_url: 'https://github.com/Netflix/metaflow'
+            logo: metaflow.svg
+            twitter: 'https://twitter.com/MetaflowOSS'
+            crunchbase: 'https://www.crunchbase.com/organization/netflix'
+          - item:
             name: PredictionIO
             homepage_url: 'https://predictionio.apache.org/'
             repo_url: 'https://github.com/apache/predictionio'
@@ -1250,13 +1257,6 @@ landscape:
             logo: luigi.svg
             twitter: null
             crunchbase: 'https://www.crunchbase.com/organization/spotify'
-          - item:
-            name: Metaflow
-            homepage_url: 'https://metaflow.org/'
-            repo_url: 'https://github.com/Netflix/metaflow'
-            logo: metaflow.svg
-            twitter: null
-            crunchbase: 'https://www.crunchbase.com/organization/netflix'
           - item:
             name: mleap
             homepage_url: 'https://mleap-docs.combust.ml'


### PR DESCRIPTION
Metaflow was incorrectly classified as a workflow orchestrator rather than an ML framework previously.

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [x] Are you only including a `repo_url` if your project is 100% open source? If so, you need to pick the single best GitHub repository for your project, not a GitHub organization.
* [x] Is your project closed source or, if it is open source, does your project have at least 250 GitHub stars?
* [x] Have you picked the single best (existing) category for your project?
* [x] Does it follow the other guidelines from the [new entries](https://github.com/cncf/landscape#new-entries) section?
* [x] Have you included a URL for your SVG or added it to `hosted_logos` and referenced it there?
* [x] Does your logo clearly state the name of the project/product and follow the other logo [guidelines](https://github.com/cncf/landscape#logos)?
* [x] Does your project/product name match the text on the logo?
* [x] Have you verified that the Crunchbase data for your organization is correct (including headquarters and LinkedIn)?
* [x] ~10 minutes after opening the pull request, the CNCF-Bot will post the URL for your staging server. Have you confirmed that it looks good to you and then added a comment to the PR saying "LGTM"?
