### PR TITLE
Remove Databricks and Red Hat entries from landscape

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -2617,15 +2617,6 @@ landscape:
         name: Premier
         items:
           - item:
-            name: Databricks Inc.
-            homepage_url: https://databricks.com/
-            logo: databricks_inc.svg
-            description: Founded in 2013 and headquartered in an Francisco, California, Databricks offers a unified platform for massive-scale data engineering, collaborative data science, full-lifecycle machine learning and business analytics.
-            crunchbase: https://www.crunchbase.com/organization/databricks
-            twitter: https://twitter.com/databricks
-            extra:
-              linkedin_url: https://www.linkedin.com/company/databricks
-          - item:
             name: Huawei Technologies Co., Ltd
             homepage_url: https://huawei.com/
             logo: huawei_technologies_co.svg
@@ -2657,15 +2648,6 @@ landscape:
             twitter: https://twitter.com/nvidia
             extra:
               linkedin_url: https://www.linkedin.com/company/nvidia
-          - item:
-            name: Red Hat LLC
-            homepage_url: https://redhat.com/
-            logo: red_hat_llc.svg
-            description: Red Hat was established in 1993 and is headquartered in Raleigh, North Carolina. Red Hat is the provider of open source software solutions, using a community-powered approach to provide reliable and high-performing cloud, Linux, middleware, storage, and virtualization technologies. Red Hat also offers support, training, and consulting services. As the connective hub in a global network of enterprises, partners, and open source communities, Red Hat helps create relevant, innovative technologies that liberate resources for growth and prepare customers for the future of IT.
-            crunchbase: https://www.crunchbase.com/organization/red-hat
-            twitter: https://twitter.com/RedHat
-            extra:
-              linkedin_url: https://www.linkedin.com/company/red-hat
           - item:
             name: ZTE Corporation
             homepage_url: https://zte.com.cn/


### PR DESCRIPTION
Removed entries for Databricks Inc. and Red Hat LLC from the landscape configuration.

# **NOTE: If you are requesting updates member organization information, please follow the instructions in the README.md file.**

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you including a `repo_url`? You need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project open source?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Have you added the SVG for your logo to `hosted_logos` and referenced it in the entry in `landscape.yml`?
* [ ] Have you verified that the Crunchbase data for your organization (including headquarters and LinkedIn) is correct?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/lfai/lfai-landscape#new-entries) section?
* [ ] ~5 minutes after opening the pull request, there will be a link to preview the entry on the staging server. Have you confirmed that it looks good?

