### PR TITLE
Remove OpenDS4All from Education subcategory

### DIFF
--- a/landscape.yml
+++ b/landscape.yml
@@ -562,13 +562,6 @@ landscape:
       - subcategory:
         name: Education
         items:
-          - item:
-            name: OpenDS4All
-            homepage_url: https://github.com/odpi/OpenDS4All
-            project: incubating
-            repo_url: https://github.com/odpi/OpenDS4All
-            logo: opends4all.svg
-            crunchbase: https://www.crunchbase.com/organization/lf-artificial-intelligence-foundation
       - subcategory:
         name: Lineage
         items:


### PR DESCRIPTION
Removed OpenDS4All item from Education subcategory.

# **NOTE: If you are requesting updates member organization information, please follow the instructions in the README.md file.**

### Pre-submission checklist:

*Please check each of these after submitting your pull request:*

* [ ] Are you including a `repo_url`? You need to pick the single best GitHub repository for your project, not a GitHub organization.
* [ ] Is your project open source?
* [ ] Have you picked the single best (existing) category for your project?
* [ ] Have you added the SVG for your logo to `hosted_logos` and referenced it in the entry in `landscape.yml`?
* [ ] Have you verified that the Crunchbase data for your organization (including headquarters and LinkedIn) is correct?
* [ ] Does it follow the other guidelines from the [new entries](https://github.com/lfai/lfai-landscape#new-entries) section?
* [ ] ~5 minutes after opening the pull request, there will be a link to preview the entry on the staging server. Have you confirmed that it looks good?

