### PR TITLE
Add Provael under Trusted & Responsible AI > Adversarial

### DIFF
--- a/hosted_logos/provael.svg
+++ b/hosted_logos/provael.svg
@@ -1,0 +1,11 @@
+<svg viewBox="0 0 512 512" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="bg" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0" stop-color="#0b2a3e"/>
+      <stop offset="1" stop-color="#0b3b52"/>
+    </linearGradient>
+  </defs>
+  <rect width="512" height="512" rx="116" fill="url(#bg)"/>
+  <path d="M150 268 L226 346 L374 166" fill="none" stroke="#19d3e0"
+        stroke-width="48" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/landscape.yml
+++ b/landscape.yml
@@ -2450,6 +2450,11 @@ landscape:
             logo: foolbox.svg
             twitter: https://twitter.com/bethgelab
             crunchbase: https://www.crunchbase.com/organization/tuebingen-university
+          - item:
+            name: Provael
+            homepage_url: https://www.provael.com
+            repo_url: https://github.com/provael/provael
+            logo: provael.svg
       - subcategory:
         name: Bias & Fairness
         items:


### PR DESCRIPTION
Adds **Provael** to Trusted & Responsible AI → **Adversarial**.

Open-source red-team and assurance harness for robot vision-language-action (VLA) policies. Runs a policy × suite × attack matrix in simulation and reports an attack-success rate with a 95% Wilson interval and a matched benign-instruction control, plus SARIF / OSCAL / CycloneDX ML-BOM evidence output.

- **Repo**: https://github.com/provael/provael (Apache-2.0)
- **Homepage**: https://www.provael.com
- Logo added at `hosted_logos/provael.svg` per the README

**Subcategory choice:** I put it under *Adversarial* rather than *Security & Privacy*. Both looked plausible from the existing entries, but Adversarial is where the adversarial-robustness tooling sits and that's what this is. Happy to move it if you'd rather.

**No `crunchbase` field** — this is an independent project with no Crunchbase entry, not an LF AI & Data member, so it's a manual `landscape.yml` addition rather than the auto-rebuilt member section. I checked that 34 of the current 471 items also omit `crunchbase`, so I don't think this blocks; say the word if it does.

Disclosure: I maintain it.